### PR TITLE
Use runtimepath and relative paths where possible

### DIFF
--- a/ftdetect/csoundft.vim
+++ b/ftdetect/csoundft.vim
@@ -1,3 +1,3 @@
 au BufNewFile,BufRead *.orc,*.sco,*.csd,*.udo   set filetype=csound
 au BufNewFile		*.csd	0r <sfile>:h/../templates/template.csd
-au BufNewFile,BufRead	*.csd	so $HOME/.vim/bundle/csound-vim/macros/csound_macros.vim
+au BufNewFile,BufRead	*.csd	runtime! macros/csound_macros.vim

--- a/ftdetect/csoundft.vim
+++ b/ftdetect/csoundft.vim
@@ -1,3 +1,3 @@
 au BufNewFile,BufRead *.orc,*.sco,*.csd,*.udo   set filetype=csound
-au BufNewFile		*.csd	0r $HOME/.vim/bundle/csound-vim/templates/template.csd
+au BufNewFile		*.csd	0r <sfile>:h/../templates/template.csd
 au BufNewFile,BufRead	*.csd	so $HOME/.vim/bundle/csound-vim/macros/csound_macros.vim

--- a/syntax/csound.vim
+++ b/syntax/csound.vim
@@ -18,7 +18,7 @@ set foldmethod=syntax
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " load list of all opcodes from a file
-source $HOME/.vim/bundle/csound-vim/syntax/csound_opcodes.vim
+runtime! syntax/csound_opcodes.vim
 
 " csound opcodes and operators
 


### PR DESCRIPTION
Hi, Steven.

This is just a personal preference, but I usually strip the "-vim" suffix or "vim-" prefix off of packages I clone into my ~/.vim directory since it's obvious to me they're for vim based on the parent directory.  This has never been a problem for me with any of my other plugins, but csound-vim didn't handle it well due to its use of "csound-vim" in its paths.

These commits patch csound-vim to look down runtimepath for the macros and syntax files.  I used runtime! (bang) so additional csound_macros.vim and csound_syntax.vim files would be sourced from the runtimepath if any existed.  Perhaps users would want these for overrides/extensions to the existing files.

Regarding the .csd skeleton, "templates" is not a subdirectory of runtime paths that vim searches, so for that one I just made it look for template.csd at a path relative to ftdetect/csoundft.vim.

Let me know what you think. 

Tested under Vim 7.3 via pathogen, Linux only.

Cheers,

Jesse

